### PR TITLE
Add iter_mut()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ impl EventHandler for Rustrisnt {
         repeat: bool,
     ) {
         if !repeat {
-            for mut player in self.vec_players.iter_mut() {
+            for player in self.vec_players.iter_mut() {
                 // POTENTIAL OPTIMIZATION: have a check elsewhere that makes sure no two input overlap and then just return after it finds what an input goes to; also in key_up_event()
                 match player.control_scheme.find_move(keycode) {
                     Movement::Left => player.input.keydown_left = (true, true),
@@ -200,7 +200,7 @@ impl EventHandler for Rustrisnt {
     }
 
     fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymod: KeyMods) {
-        for mut player in self.vec_players.iter_mut() {
+        for player in self.vec_players.iter_mut() {
             match player.control_scheme.find_move(keycode) {
                 Movement::Left => player.input.keydown_left = (false, false),
                 Movement::Right => player.input.keydown_right = (false, false),

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ impl EventHandler for Rustrisnt {
 
         // Update code here...
 
-        for player in self.vec_players.iter() {
+        for player in self.vec_players.iter_mut() {
             // piece spawning
             if player.spawn_piece_flag {
                 player.spawn_piece_flag = false;
@@ -185,7 +185,7 @@ impl EventHandler for Rustrisnt {
         repeat: bool,
     ) {
         if !repeat {
-            for mut player in self.vec_players {
+            for mut player in self.vec_players.iter_mut() {
                 // POTENTIAL OPTIMIZATION: have a check elsewhere that makes sure no two input overlap and then just return after it finds what an input goes to; also in key_up_event()
                 match player.control_scheme.find_move(keycode) {
                     Movement::Left => player.input.keydown_left = (true, true),
@@ -200,7 +200,7 @@ impl EventHandler for Rustrisnt {
     }
 
     fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymod: KeyMods) {
-        for mut player in self.vec_players {
+        for mut player in self.vec_players.iter_mut() {
             match player.control_scheme.find_move(keycode) {
                 Movement::Left => player.input.keydown_left = (false, false),
                 Movement::Right => player.input.keydown_right = (false, false),


### PR DESCRIPTION
This fix is rather simple, just use iter_mut() instead of iter() or &
for de-referenced iter() if already a vec

See: https://doc.rust-lang.org/std/primitive.slice.html#method.iter_mut