### PR TITLE
next pieces work

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -81,7 +81,6 @@ impl Board {
                     if self.is_row_full(*row) {
                         is_full_line = true;
                         self.vec_full_lines.push(FullLine::new(*row, player));
-                        println!("pushed a thing to the thing with row {}, player {}", *row, player);
                     }
                 }
                 if is_full_line {
@@ -206,7 +205,6 @@ impl Board {
                 }
             }
             checked_lines_for_scoring += lines_player_cleared;
-            println!("adding appropriate score for being at level {}, clearing {} lines", level, lines_player_cleared);
             score += match lines_player_cleared {
                 1 => SCORE_SINGLE_BASE as u32 * (level as u32 + 1),
                 2 => SCORE_DOUBLE_BASE as u32 * (level as u32 + 1),

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -1,7 +1,7 @@
 use crate::board::BOARD_HEIGHT_BUFFER_U;
 
 #[repr(u8)]
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub enum Shapes {
     None,
     I,
@@ -37,6 +37,51 @@ impl Piece {
             shape,
             positions: [(0xff, 0xff); 4],
             rotation: 0,
+        }
+    }
+
+    pub fn new_next(shape: Shapes) -> Self {
+        match shape {
+            Shapes::None => return Self {
+                shape,
+                positions: [(0xff, 0xff); 4],
+                rotation: 0,
+            },
+            Shapes::I => return Self {
+                shape,
+                positions: [(0, 0), (0, 1), (0, 2), (0, 3)],
+                rotation: 0,
+            },
+            Shapes::O => return Self {
+                shape,
+                positions: [(0, 1), (0, 2), (1, 1), (1, 2)],
+                rotation: 0,
+            },
+            Shapes::T => return Self {
+                shape,
+                positions: [(0, 1), (0, 2), (0, 3), (1, 2)],
+                rotation: 0,
+            },
+            Shapes::J => return Self {
+                shape,
+                positions: [(0, 1), (0, 2), (0, 3), (1, 3)],
+                rotation: 0,
+            },
+            Shapes::L => return Self {
+                shape,
+                positions: [(0, 1), (0, 2), (0, 3), (1, 1)],
+                rotation: 0,
+            },
+            Shapes::S => return Self {
+                shape,
+                positions: [(0, 2), (0, 3), (1, 1), (1, 2)],
+                rotation: 0,
+            },
+            Shapes::Z => return Self {
+                shape,
+                positions: [(0, 0), (0, 1), (0, 2), (1, 1)],
+                rotation: 0,
+            },
         }
     }
 
@@ -210,6 +255,31 @@ impl Piece {
                     }
                 }
             }
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub struct NextPiece {
+    pub shape: Shapes,
+    pub matrix: [[bool; 4]; 2],
+}
+
+impl NextPiece {
+    pub fn new(shape: Shapes) -> Self {
+        if shape == Shapes::None {
+            return Self {
+                shape,
+                matrix: [[false; 4]; 2],
+            }
+        }
+        let mut matrix: [[bool; 4]; 2] = [[false; 4]; 2];
+        for position in Piece::new_next(shape).positions.iter().take(4) {
+            matrix[position.0 as usize][position.1 as usize] = true;
+        }
+        Self {
+            shape,
+            matrix,
         }
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,4 +1,5 @@
 use crate::controls::{Input, ControlScheme};
+use crate::piece::{Piece, Shapes};
 
 pub const SPAWN_DELAY: i16 = 20i16;
 
@@ -9,6 +10,7 @@ pub struct Player {
     pub spawn_piece_flag: bool,
     pub spawn_column: u8,
     pub spawn_delay: i16,
+    pub next_piece: Piece,
 }
 
 impl Player {
@@ -20,6 +22,7 @@ impl Player {
             spawn_piece_flag: true,
             spawn_column,
             spawn_delay: SPAWN_DELAY,
+            next_piece: Piece::new_next(Shapes::None),
         }
     }
 }


### PR DESCRIPTION
I went for drawing the next pieces above the board because it only takes 4 more tiles of height, which is not much, and it is easier to find your own next piece when it just hovers above where it will spawn.  
There's still a graphical bug for clearing lines, but once I determine what should be done to fix that, I'll do it.  
My plan is to have the main logic be a library and to keep all graphical stuff separate (aside from TileGraphic stuff), so that if I (or geno lol) wants to try making a different game or using a different game engine, it won't be very hard, but using a matrix of SpriteIndex's is the right way to do it, so not entirely sure how to map everything together at this point. Too bad 